### PR TITLE
fix(updatecli): Documents the UBI9 tag retrieval.

### DIFF
--- a/updatecli/scripts/ubi9-latest-tag.md
+++ b/updatecli/scripts/ubi9-latest-tag.md
@@ -1,0 +1,97 @@
+# Red Hat Container Catalog API Documentation
+
+## Overview
+
+The script fetches the latest tag from the Red Hat Container Catalog API for UBI9 images. It ensures that `jq` and `curl` are installed, fetches the tags, and processes them to find the unique tag.
+
+## API Endpoints
+
+The Swagger API endpoints for the Red Hat Container Catalog API are documented at:
+[https://catalog.redhat.com/api/containers/v1/ui/#/Repositories/graphql.images.get_images_by_repo](https://catalog.redhat.com/api/containers/v1/ui/#/Repositories/graphql.images.get_images_by_repo)
+
+## API Description
+
+The Red Hat Container Catalog API, which provides the tag information, is described in the Swagger API documentation:
+[https://catalog.redhat.com/api/containers/v1/ui/#/Repositories/graphql.images.get_images_by_repo](https://catalog.redhat.com/api/containers/v1/ui/#/Repositories/graphql.images.get_images_by_repo)
+
+We would use:
+- `registry.access.redhat.com` in the `registry` field
+- `ubi9` in the `repository` field
+- `100` in the `page_size` field
+- `0` in the `page` field
+- `last_update_date[desc]` in the `sort_by` field
+
+### Parameters
+* registry: `registry.access.redhat.com`  
+  * This specifies the registry from which we are fetching the images. In this case, it is the Red Hat Container Catalog.
+* repository: `ubi9`  
+  * This specifies the repository within the registry. Here, we are interested in the UBI9 (Universal Base Image 9) repository.
+* page_size: `100`  
+  * This sets the number of results to return per page. We set it to 100 to ensure we get a sufficient number of tags in one request.
+* page: `0`  
+  * This specifies the page number to fetch. We start with page 0 to get the first set of results.
+* sort_by: `last_update_date[desc]`  
+  * This sorts the results by the `last_update_date` field in descending order. This ensures that the most recently updated tags are listed first.
+
+### Curl Command
+The curl command is used to make an HTTP GET request to the Red Hat Container Catalog API with the specified parameters. It fetches the JSON data containing the tags for the UBI9 images.
+Click on "Execute" to get a curl command such as:
+
+```sh
+curl -X 'GET' \
+  'https://catalog.redhat.com/api/containers/v1/repositories/registry/registry.access.redhat.com/repository/ubi9/images?page_size=100&page=0&sort_by=last_update_date%5Bdesc%5D' \
+  -H 'accept: application/json'
+``` 
+* `-X 'GET'`: Specifies the HTTP method to use, which is GET in this case.
+* `URL`: The URL constructed with the parameters to fetch the UBI9 image tags.
+* `-H 'accept: application/json'`: Sets the request header to accept JSON responses.
+
+The result would then contain something like:
+
+```json
+{
+  "added_date": "2024-11-28T15:34:55.940000+00:00",
+  "name": "latest",
+  "_links": {
+    "tag_history": {
+      "href": "/v1/tag-history/registry/registry.access.redhat.com/repository/ubi9/tag/latest"
+    }
+  }
+}
+```
+
+That's the beginning of what we're looking for. This will guide us to the tag considered the latest by RedHat. 
+If we look closely at the preceding sibling in the JSON file, we'll find something like :
+
+```json
+{
+  "added_date": "2024-11-28T15:34:55.940000+00:00",
+  "name": "9.5-1732804088",
+  "_links": {
+    "tag_history": {
+      "href": "/v1/tag-history/registry/registry.access.redhat.com/repository/ubi9/tag/9.5-1732804088"
+    }
+  }
+},
+{
+  "added_date": "2024-11-28T15:34:55.940000+00:00",
+  "name": "latest",
+  "_links": {
+    "tag_history": {
+      "href": "/v1/tag-history/registry/registry.access.redhat.com/repository/ubi9/tag/latest"
+    }
+  }
+}
+```
+What lies in the value associated to the `"name"` key in the first data structure is what we're looking for.
+That's why in the script we are searching for all values associated to the `"name"` key in the data block where we found `"latest"`:
+
+```bash
+latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name == "latest") | .tags[] | select(.name != "latest") | .name')
+``` 
+
+Later on in the script, we'll focus on the values that contain `-`, because we're only interested in the long-form tag name (`9.5-1732804088` and not `9.5`). We'll also keep only one instance of the tag, just in case the JSON would contain duplicates.
+
+```bash
+unique_tag=$(echo "$latest_tag" | sort | uniq | grep -v latest | grep "-")
+```

--- a/updatecli/scripts/ubi9-latest-tag.md
+++ b/updatecli/scripts/ubi9-latest-tag.md
@@ -82,10 +82,10 @@ What lies in the value associated to the `"name"` key in the first data structur
 That's why in the script we are searching for all values associated to the `"name"` key in the data block where we found `"latest"`:
 
 ```bash
-latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name == "latest") | .tags[] | select(.name != "latest") | .name')
+latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name == "latest") | .tags[] | select(.name != "latest" and (.name | contains("-"))) | .name' | sort -u)
 ``` 
 
-Later on in the script, we'll focus on the values that contain `-`, because we're only interested in the long-form tag name (`9.5-1732804088` and not `9.5`). We'll also keep only one instance of the tag, just in case the JSON would contain duplicates.
+As you can see, we focus on the values that contain `-`, because we're only interested in the long-form tag name (`9.5-1732804088` and not `9.5`). We'll also keep only one instance of the tag, just in case the JSON would contain duplicates.
 
 ```bash
 unique_tag=$(echo "$latest_tag" | sort | uniq | grep -v latest | grep "-")

--- a/updatecli/scripts/ubi9-latest-tag.md
+++ b/updatecli/scripts/ubi9-latest-tag.md
@@ -20,7 +20,7 @@ We would use:
 - registry: `registry.access.redhat.com`  
   - This specifies the registry from which we are fetching the images. In this case, it is the Red Hat Container Catalog.
 - repository: `ubi9`  
-  - This specifies the repository within the registry. Here, we are interested in the UBI9 (Universal Base Image 9) repository. Whenever there is a UBI10, we will then change `ubi9` to `ubi10`, if the API doesn't change by then.
+  - This specifies the repository within the registry. Here, we are interested in the UBI9 (Universal Base Image 9) repository.
 - page_size: `100`  
   - This sets the number of results to return per page. We set it to 100 to ensure we get a sufficient number of tags in one request.
 - page: `0`  
@@ -45,6 +45,11 @@ curl -X 'GET' \
 - `-X 'GET'`: Specifies the HTTP method to use, which is GET in this case.
 - `URL`: The URL constructed with the parameters to fetch the UBI9 image tags.
 - `-H 'accept: application/json'`: Sets the request header to accept JSON responses.
+- `--fail`: Fail silently on HTTP errors
+- `--silent`: Don't show progress meter or error messages
+- `--show-error`: Show error message if it fails
+- `--retry 3`: Retry failed requests up to 3 times
+- `--retry-delay 2`: Wait 2 seconds between retries
 
 The result would then contain something like:
 
@@ -84,7 +89,9 @@ If we look closely at the preceding sibling in the JSON file, we'll find somethi
 }
 ```
 What lies in the value associated to the `"name"` key in the first data structure is what we're looking for.
-Up to now, we've seen this long-form version value appearing always before the `"latest"` value, but the order in which they information is supposed to appear is not documented, we are thus searching for all values associated to the `"name"` key in the data block where we found `"latest"`, wherever they may be in the data block:
+While the long-form version value typically appears before the `"latest"` value, the order is not documented.
+Therefore, we search for all values associated with the `"name"` key in the data block containing `"latest"`,
+regardless of their position:
 
 ```bash
 latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name == "latest") | .tags[] | select(.name != "latest" and (.name | contains("-"))) | .name' | sort -u)

--- a/updatecli/scripts/ubi9-latest-tag.md
+++ b/updatecli/scripts/ubi9-latest-tag.md
@@ -4,11 +4,6 @@
 
 The script fetches the latest tag from the Red Hat Container Catalog API for UBI9 images. It ensures that `jq` and `curl` are installed, fetches the tags, and processes them to find the unique tag.
 
-## API Endpoints
-
-The Swagger API endpoints for the Red Hat Container Catalog API are documented at:
-[https://catalog.redhat.com/api/containers/v1/ui/#/Repositories/graphql.images.get_images_by_repo](https://catalog.redhat.com/api/containers/v1/ui/#/Repositories/graphql.images.get_images_by_repo)
-
 ## API Description
 
 The Red Hat Container Catalog API, which provides the tag information, is described in the Swagger API documentation:
@@ -22,16 +17,16 @@ We would use:
 - `last_update_date[desc]` in the `sort_by` field
 
 ### Parameters
-* registry: `registry.access.redhat.com`  
-  * This specifies the registry from which we are fetching the images. In this case, it is the Red Hat Container Catalog.
-* repository: `ubi9`  
-  * This specifies the repository within the registry. Here, we are interested in the UBI9 (Universal Base Image 9) repository.
-* page_size: `100`  
-  * This sets the number of results to return per page. We set it to 100 to ensure we get a sufficient number of tags in one request.
-* page: `0`  
-  * This specifies the page number to fetch. We start with page 0 to get the first set of results.
-* sort_by: `last_update_date[desc]`  
-  * This sorts the results by the `last_update_date` field in descending order. This ensures that the most recently updated tags are listed first.
+- registry: `registry.access.redhat.com`  
+  - This specifies the registry from which we are fetching the images. In this case, it is the Red Hat Container Catalog.
+- repository: `ubi9`  
+  - This specifies the repository within the registry. Here, we are interested in the UBI9 (Universal Base Image 9) repository.
+- page_size: `100`  
+  - This sets the number of results to return per page. We set it to 100 to ensure we get a sufficient number of tags in one request.
+- page: `0`  
+  - This specifies the page number to fetch. We start with page 0 to get the first set of results.
+- sort_by: `last_update_date[desc]`  
+  - This sorts the results by the `last_update_date` field in descending order. This ensures that the most recently updated tags are listed first.
 
 ### Curl Command
 The curl command is used to make an HTTP GET request to the Red Hat Container Catalog API with the specified parameters. It fetches the JSON data containing the tags for the UBI9 images.
@@ -42,9 +37,9 @@ curl -X 'GET' \
   'https://catalog.redhat.com/api/containers/v1/repositories/registry/registry.access.redhat.com/repository/ubi9/images?page_size=100&page=0&sort_by=last_update_date%5Bdesc%5D' \
   -H 'accept: application/json'
 ``` 
-* `-X 'GET'`: Specifies the HTTP method to use, which is GET in this case.
-* `URL`: The URL constructed with the parameters to fetch the UBI9 image tags.
-* `-H 'accept: application/json'`: Sets the request header to accept JSON responses.
+- `-X 'GET'`: Specifies the HTTP method to use, which is GET in this case.
+- `URL`: The URL constructed with the parameters to fetch the UBI9 image tags.
+- `-H 'accept: application/json'`: Sets the request header to accept JSON responses.
 
 The result would then contain something like:
 

--- a/updatecli/scripts/ubi9-latest-tag.md
+++ b/updatecli/scripts/ubi9-latest-tag.md
@@ -103,4 +103,4 @@ latest_tag=$(echo "$response" | jq -r '
 ' | sort -u)
 ``` 
 
-As you can see, we focus on the values that contain `-`, because we're only interested in the long-form tag name (`9.5-1732804088` and not `9.5`). We'll also keep only one instance of the tag, just in case the JSON would contain duplicates.
+As you can see, we focus on the values that contain `-` because we're only interested in the long-form tag name (`9.5-1732804088` and not `9.5`). We'll also keep only one instance of the tag, just in case the JSON would contain duplicates.

--- a/updatecli/scripts/ubi9-latest-tag.md
+++ b/updatecli/scripts/ubi9-latest-tag.md
@@ -30,7 +30,7 @@ We would use:
 
 ### Curl Command
 The curl command is used to make an HTTP GET request to the Red Hat Container Catalog API with the specified parameters. It fetches the JSON data containing the tags for the UBI9 images.
-Click on "Execute" to get a curl command such as:
+Within the Swagger RedHat UI, once you have entered the right data in the fields, click on "Execute" to get a curl command such as:
 
 ```sh
 curl -X 'GET' \
@@ -94,7 +94,13 @@ Therefore, we search for all values associated with the `"name"` key in the data
 regardless of their position:
 
 ```bash
-latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name == "latest") | .tags[] | select(.name != "latest" and (.name | contains("-"))) | .name' | sort -u)
+latest_tag=$(echo "$response" | jq -r '
+  .data[].repositories[]                                   # Iterate through repositories
+  | select(.tags[].name == "latest")                 # Find repository containing "latest" tag
+  | .tags[]                                                      # Iterate through all tags
+  | select(.name != "latest" and (.name | contains("-"))) # Select non-latest tags containing "-"
+  | .name                                                      # Extract tag name
+' | sort -u)
 ``` 
 
 As you can see, we focus on the values that contain `-`, because we're only interested in the long-form tag name (`9.5-1732804088` and not `9.5`). We'll also keep only one instance of the tag, just in case the JSON would contain duplicates.

--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -29,7 +29,12 @@ if ! command -v jq >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
 fi
 
 # Fetch the tags using curl, for `ub9`, in the `registry.access.redhat.com`, sorted by last update date descending, and keeping only page 0.
-response=$(curl --silent --fail --location --connect-timeout 10 --max-time 30 --header 'accept: application/json' "$URL")
+# --fail: Fail silently on HTTP errors
+# --silent: Don't show progress meter or error messages
+# --show-error: Show error message if it fails
+# --retry 3: Retry failed requests up to 3 times
+# --retry-delay 2: Wait 2 seconds between retries
+response=$(curl --silent --fail --location --connect-timeout 10 --retry 3 --retry-delay 2 --max-time 30 --header 'accept: application/json' "$URL")
 
 # Check if the response is empty or null
 if [ -z "$response" ] || [ "$response" == "null" ]; then

--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -1,10 +1,22 @@
 #!/bin/bash
 
 # This script fetches the latest tag from the Red Hat Container Catalog API for UBI9 images.
-# It ensures that `jq` and `curl` are installed, fetches the tags, and processes them to find the unique tag.
+# It ensures that `jq` and `curl` are installed, fetches the most recent tags, and processes them to find the unique tag associated to `latest`s.
 
 # The Swagger API endpoints for the Red Hat Container Catalog API are documented at:
 # https://catalog.redhat.com/api/containers/v1/ui/#/Repositories/graphql.images.get_images_by_repo
+
+# The script uses the following parameters for the API request:
+# - registry: registry.access.redhat.com
+# - repository: ubi9
+# - page_size: 100
+# - page: 0
+# - sort_by: last_update_date[desc]
+
+# The curl command fetches the JSON data containing the tags for the UBI9 images.
+# The script then parses the JSON response using jq to find the version associated with the "latest" tag.
+# It focuses on tags that contain a hyphen, as these represent the long-form tag names.
+# The script ensures that only one instance of each tag is kept, in case of duplicates.
 
 # Correct URL of the Red Hat Container Catalog API for UBI9
 URL="https://catalog.redhat.com/api/containers/v1/repositories/registry/registry.access.redhat.com/repository/ubi9/images?page_size=100&page=0&sort_by=last_update_date%5Bdesc%5D"
@@ -16,7 +28,7 @@ if ! command -v jq >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
     exit 1
 fi
 
-# Fetch the tags using curl
+# Fetch the tags using curl, for `ub9`, in the `registry.access.redhat.com`, sorted by last update date descending, and keeping only page 0.
 response=$(curl --silent --fail --location --connect-timeout 10 --max-time 30 --header 'accept: application/json' "$URL")
 
 # Check if the response is empty or null

--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -26,7 +26,7 @@ if [ -z "$response" ] || [ "$response" == "null" ]; then
 fi
 
 # Parse the JSON response using jq to find the version associated with the "latest" tag
-latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name == "latest") | .tags[] | select(.name != "latest") | .name')
+latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name == "latest") | .tags[] | select(.name != "latest" and (.name | contains("-"))) | .name' | sort -u)
 
 # Check if the latest_tag is empty
 if [ -z "$latest_tag" ]; then
@@ -34,11 +34,8 @@ if [ -z "$latest_tag" ]; then
   exit 1
 fi
 
-# Sort and remove duplicates
-unique_tag=$(echo "$latest_tag" | sort | uniq | grep -v latest | grep "-")
-
 # Trim spaces
-unique_tag=$(echo "$unique_tag" | xargs)
+unique_tag=$(echo "$latest_tag" | xargs)
 
 # Output the latest version
 echo "$unique_tag"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for the script that retrieves the latest tag from the Red Hat Container Catalog API for UBI9 images.
	- Enhanced details on prerequisites, API endpoints, and parameters for requests, including links to Swagger API documentation.
	- Clarified the process of filtering and processing JSON responses to ensure only relevant unique tags are extracted.

- **New Features**
	- Improved logic for tag selection by filtering tags that contain a hyphen (`-`).
	- Streamlined processing steps for fetching and outputting the latest tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->