### PR TITLE
Bump JDK17 version to 17.0.15+6

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ $ make show
       "dockerfile": "alpine/Dockerfile",
       "args": {
         "ALPINE_TAG": "3.21.3",
-        "JAVA_VERSION": "17",
+        "JAVA_VERSION": "17.0.15+6",
         "VERSION": "3309.v27b_9314fd1a_4"
       },
       "tags": [
@@ -184,7 +184,7 @@ $ ON_TAG=true BUILD_NUMBER=3 make show
       "dockerfile": "alpine/Dockerfile",
       "args": {
         "ALPINE_TAG": "3.21.3",
-        "JAVA_VERSION": "17",
+        "JAVA_VERSION": "17.0.15+6",
         "VERSION": "3309.v27b_9314fd1a_4"
       },
       "tags": [


### PR DESCRIPTION



<Actions>
    <action id="04b8a347a72ce9b63c57d30f47d1466887f35fcae7350f100cc85d0dd91226ab">
        <h3>Bump JDK17 version</h3>
        <details id="03eef07d39ce0ac56a1a3a015b9d60eedfb645a7cdfcdfb9e76f4873b2c42f12">
            <summary>Bump JDK17 version in README.md file</summary>
            <p>1 file(s) updated with &#34;\&#34;JAVA_VERSION\&#34;: \&#34;17.0.15+6\&#34;$2&#34;:&#xA;&#x9;* README.md&#xA;</p>
            <details>
                <pre>https://adoptium.net/temurin/release-notes/?version=&#xA;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README examples to specify the Java version as "17.0.15+6" instead of "17" in command outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->