### PR TITLE
Ubi9 updatecli script fix @coderabbitai 

### DIFF
--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -37,7 +37,18 @@ if [ -z "$response" ] || [ "$response" == "null" ]; then
 fi
 
 # Parse the JSON response using jq to find the version associated with the "latest" tag
-latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name == "latest") | .tags[] | select(.name != "latest" and (.name | contains("-"))) | .name' | sort -u | xargs)
+# - The response is expected to be a JSON object containing repository data.
+# - The script uses `jq` to:
+#   1. Iterate over all repositories in the `data` array.
+#   2. Select repositories where at least one tag has the name "latest".
+#   3. From those repositories, select tags that:
+#      - Do not have the name "latest".
+#      - Contain a hyphen in their name (indicating a long-form tag).
+#   4. Extract the `name` of the matching tags.
+#   5. Sort the tag names uniquely (`sort -u`).
+#   6. Take the last tag in the sorted list (`tail -n 1`), which is assumed to be the most recent valid tag.
+latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name == "latest") | .tags[] | select(.name != "latest" and (.name | contains("-"))) | .name' | sort -u | tail -n 1)
+
 
 # Check if the latest_tag is empty
 if [ -z "$latest_tag" ]; then

--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -36,8 +36,8 @@ if [ -z "$response" ] || [ "$response" == "null" ]; then
   exit 1
 fi
 
-# Parse the JSON response using jq to find the most recent version
-latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name != "latest") | .tags[] | .name ' | sort -u | tail -n 1)
+# Parse the JSON response using jq to find the version associated with the "latest" tag
+latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name == "latest") | .tags[] | select(.name != "latest" and (.name | contains("-"))) | .name' | sort -u | xargs)
 
 # Check if the latest_tag is empty
 if [ -z "$latest_tag" ]; then


### PR DESCRIPTION

## Summary of Changes
This pull request addresses an issue in the `ubi9-latest-tag.sh` script, which is responsible for determining the latest UBI9 tag. The original script logic was flawed in how it parsed the JSON response from the registry API to identify the correct tag. This update modifies the `jq` command to more accurately extract the latest tag associated with the "latest" tag, specifically looking for tags that contain a hyphen (which indicates a long-form tag) and are not named "latest".

### Highlights
* **Bug Fix**: The pull request fixes a bug in the `ubi9-latest-tag.sh` script that caused it to incorrectly identify the latest UBI9 tag.
* **Improved Tag Parsing**: The `jq` command in the script has been updated to more accurately parse the JSON response and extract the correct tag, ensuring that it selects tags associated with the "latest" tag that also contain a hyphen.

### Changelog
* **updatecli/scripts/ubi9-latest-tag.sh**
  * Modified the `jq` command to correctly parse the JSON response and identify the latest UBI9 tag.
  * Added a filter to select tags associated with the "latest" tag that also contain a hyphen in their name.
  * Added comments to explain the logic of the `jq` command.
