### PR TITLE
Add java 25 target for all images

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -42,15 +42,14 @@ RUN apk add --no-cache \
 ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 
 RUN case "$(jlink --version 2>&1)" in \
-      "17."*) set -- "--compress=2" ;; \
-      # the compression argument is different for JDK21
-      "21."*) set -- "--compress=zip-6" ;; \
-      *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
+      "17."*) options="--compress=2 --add-modules ALL-MODULE-PATH" ;; \
+      "21."*) options="--compress=zip-6 --add-modules ALL-MODULE-PATH" ;; \
+      "25"*) options="--compress=zip-6 --add-modules java.base,java.logging,java.xml,java.se" ;; \
+      *) echo "Unsupported Java version ($(jlink --version 2>&1))" && exit 1 ;; \
     esac; \
     jlink \
       --strip-java-debug-attributes \
-      "$1" \
-      --add-modules ALL-MODULE-PATH \
+      ${options} \
       --no-man-pages \
       --no-header-files \
       --output /javaruntime

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -47,15 +47,14 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 # while still saving space (approx 200mb from the full distribution)
 RUN if [[ "${TARGETPLATFORM}" != "linux/arm/v7" ]]; then \
     case "$(jlink --version 2>&1)" in \
-      "17."*) set -- "--compress=2" ;; \
-      # the compression argument is different for JDK21
-      "21."*) set -- "--compress=zip-6" ;; \
-      *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
+      "17."*) options="--compress=2 --add-modules ALL-MODULE-PATH" ;; \
+      "21."*) options="--compress=zip-6 --add-modules ALL-MODULE-PATH" ;; \
+      "25"*) options="--compress=zip-6 --add-modules java.base,java.logging,java.xml,java.se" ;; \
+      *) echo "Unsupported Java version ($(jlink --version 2>&1))" && exit 1 ;; \
     esac; \
-    jlink \
-      --strip-java-debug-attributes \
-      "$1" \
-      --add-modules ALL-MODULE-PATH \
+    jlink --strip-java-debug-attributes \
+      ${options} \
+      --module-path /opt/jdk-${JAVA_VERSION}/jmods \
       --no-man-pages \
       --no-header-files \
       --output /javaruntime; \

--- a/rhel/ubi9/Dockerfile
+++ b/rhel/ubi9/Dockerfile
@@ -24,15 +24,14 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
 RUN case "$(jlink --version 2>&1)" in \
-      "17."*) set -- "--compress=2" ;; \
-      # the compression argument is different for JDK21
-      "21."*) set -- "--compress=zip-6" ;; \
-      *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
+      "17."*) options="--compress=2 --add-modules ALL-MODULE-PATH --module-path /opt/jdk-${JAVA_VERSION}/jmods" ;; \
+      "21."*) options="--compress=zip-6 --add-modules ALL-MODULE-PATH --module-path /opt/jdk-${JAVA_VERSION}/jmods" ;; \
+      "25"*) options="--compress=zip-6 --add-modules java.base,java.logging,java.xml,java.se --module-path /opt/jdk-${JAVA_VERSION}/lib" ;; \
+      *) echo "Unsupported Java version ($(jlink --version 2>&1))" && exit 1 ;; \
     esac; \
     jlink \
       --strip-java-debug-attributes \
-      "$1" \
-      --add-modules ALL-MODULE-PATH \
+      ${options} \
       --no-man-pages \
       --no-header-files \
       --output /javaruntime

--- a/updatecli/updatecli.d/jdk25.yaml
+++ b/updatecli/updatecli.d/jdk25.yaml
@@ -1,0 +1,74 @@
+---
+name: Bump JDK25 version for all Linux images
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+  temurin25-binaries:
+    kind: "github"
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "adoptium"
+      repository: "temurin25-binaries"
+      token: '{{ requiredEnv .github.token }}'
+      branch: "main"
+
+sources:
+  latestJDK25Version:
+    kind: temurin
+    name: Get the latest Adoptium JDK25 version via the API
+    spec:
+      featureversion: 25
+      releasetype: "ea"
+    transformers:
+      - trimprefix: "jdk-"
+
+# Architectures must match those of the targets in docker-bake.hcl
+conditions:
+  checkTemurinAllReleases:
+    name: Check if the "<latestJDK25Version>" is available for all platforms
+    kind: temurin
+    sourceid: latestJDK25Version
+    spec:
+      featureversion: 25
+      releasetype: "ea"
+      platforms:
+        - alpine-linux/x64
+        - alpine-linux/aarch64
+        - linux/x64
+        - linux/aarch64
+        - linux/ppc64le
+        - linux/s390x
+        - windows/x64
+
+targets:
+  setJDK25VersionDockerBake:
+    name: "Bump JDK25 version for Linux images in the docker-bake.hcl file"
+    kind: hcl
+    transformers:
+      - replacer:
+          from: "+"
+          to: "_"
+    spec:
+      file: docker-bake.hcl
+      path: variable.JAVA25_VERSION.default
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump JDK25 version to {{ source "latestJDK25Version" }}
+    spec:
+      labels:
+        - dependencies
+        - jdk25


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added JDK 25 support across Linux images, with optimized runtime modules and compression.
  - Enabled separate JDK selection for Windows builds, aligning cross-platform consistency.
- Refactor
  - Unified jlink option handling for clearer, consistent runtime creation across Java versions.
  - Made version-aware error messages more descriptive for unsupported Java versions.
- Chores
  - Included JDK 25 in the default build matrix.
  - Automated JDK 25 version updates via CI configuration to track latest early-access releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->