### PR TITLE
feat: Add linux/riscv64 platform support for Debian images

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -240,8 +240,8 @@ function "alpine_platforms" {
 function "debian_platforms" {
   params = [jdk]
   result = (equal(17, jdk)
-    ? ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/arm/v7"]
-  : ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"])
+    ? ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/arm/v7", "linux/riscv64"]
+  : ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x", "linux/riscv64"])
 }
 
 # Return array of Windows version(s) to build


### PR DESCRIPTION
## Summary

- Add `linux/riscv64` to the `debian_platforms` function in `docker-bake.hcl` for all JDK versions (17, 21, 25)
- Debian trixie (already the project's base) provides riscv64 images
- Adoptium Temurin provides JDK 17, 21, and 25 builds for riscv64
- QEMU user-static already includes `qemu-riscv64-static` for cross-architecture builds

## Context

Addresses jenkinsci/docker-agent#1168 — request for riscv64 Docker image support.

Verified locally:
- `ARCH=riscv64 make list` correctly shows all 6 Debian targets
- Successfully built `agent_debian_jdk21` and `agent_debian_jdk25` for riscv64 via QEMU
- All three Adoptium JDK versions (17.0.18+8, 21.0.10+7, 25.0.2+10) confirmed available for riscv64

## Test plan

- [ ] CI builds pass for existing architectures (no regression)
- [ ] riscv64 images build successfully via QEMU in multi-arch builds
- [ ] `java -version` works correctly in the riscv64 images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RISC-V 64-bit architecture support to Debian Docker builds, expanding platform compatibility across additional hardware systems. This new architecture is now consistently available across all supported Java versions, including JDK 17, providing greater flexibility for diverse deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->